### PR TITLE
Fix to Reflection

### DIFF
--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/Reflection/Assembly.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/Reflection/Assembly.lua
@@ -952,19 +952,6 @@ define("System.Activator", {
     local T, n = type[1], select("#", ...)
     if n == 0 then
       return createInstance(T)
-    elseif n == 1 then
-      local args = ...
-      if System.isArrayLike(args) then
-        n = #args
-        if n == 0 then
-          return createInstance(T)
-        end
-        local i = findMatchCtor(T, n, function (i, args) return args:get(i - 1) end, args)
-        if i and i ~= 1 then
-          return System.new(T, i, unpack(args, 1, n))
-        end
-        return T(unpack(args, 1, n))
-      end
     end
     local i = findMatchCtor(T, n, select, ...)
     if i and i ~= 1 then


### PR DESCRIPTION
Fix lets the creation of classes that can override UnitEntity's methods to perform own actions.
`public class UnitEntity{
public UnitEntity(unit u){// constructor logic}
public virtual float WeaponDamage(){
return 100;
}
}`
`public class Footman : UnitEntity{
public Footman(unit u) : base(u){ // other logic}
public WeaponDamage(){
return base.WeaponDamage() * 10; // when damage engine caches it, it really returns 1000
}
}`
Example, but damage comes from real weapon aka 8 for footman and 17 for rifleman, but there is a class Footman which overrides it *10 aka 80.
![image](https://user-images.githubusercontent.com/52426335/66951573-976d0680-f052-11e9-9285-a07afbe697f0.png)
